### PR TITLE
fix: espaço em branco nos caminhos de diretório causando conflito

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -10,6 +10,6 @@ const PASTA_PUBLIC = __DIR__;
  Configura todo o necessário para a inicialização do app como buscar as
  constantes, carregar as funções auxiliares e registrar o autoloader adequado;
 ---------------------------------------------------------------------- */
-require '../system/Core/iniciar_app.php';
+require __DIR__.'/../system/Core/iniciar_app.php';
 
 Hefestos\Core\App::processarRequisicao();

--- a/system/CLI/CLI.php
+++ b/system/CLI/CLI.php
@@ -36,7 +36,7 @@ class CLI
 
         echo("\n\033[92m# Servidor de desenvolvimento do HefestosPHP deve ser iniciado em http://$url.\n");
         echo("\033[93m# Pressione ctrl+c para interromper.\033[0m\n");
-        exec("php -S $url -t ". PASTA_PUBLIC);
+        exec("php -S $url -t ". '"'. PASTA_PUBLIC . '"');
     }
 
 


### PR DESCRIPTION
Caminhos que incluíam espaços em branco (ex: Área de trabalho) resultavam em erros para encontrar os diretórios.